### PR TITLE
Update the way katana behaves when crashing

### DIFF
--- a/bin/solis/src/args.rs
+++ b/bin/solis/src/args.rs
@@ -10,6 +10,7 @@
 //!   documentation for usage details. This is **not recommended on Windows**. See [here](https://rust-lang.github.io/rfcs/1974-global-allocators.html#jemalloc)
 //!   for more info.
 
+use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -85,7 +85,7 @@ impl<EF: ExecutorFactory> KatanaSequencer<EF> {
         #[cfg(feature = "messaging")]
         let messaging = if let Some(config) = config.messaging.clone() {
             match &hooker {
-                Some(hooker_ref) => MessagingService::new(
+                Some(hooker_ref) => MessagingService::new(//ici !!
                     config,
                     Arc::clone(&pool),
                     Arc::clone(&backend),
@@ -109,7 +109,7 @@ impl<EF: ExecutorFactory> KatanaSequencer<EF> {
             miner,
             block_producer.clone(),
             #[cfg(feature = "messaging")]
-            messaging,
+            messaging, //ici !!
         ));
 
         Ok(Self { pool, config, backend, block_producer, hooker })

--- a/crates/katana/core/src/service/messaging/mod.rs
+++ b/crates/katana/core/src/service/messaging/mod.rs
@@ -159,13 +159,13 @@ pub trait Messenger {
     ///
     /// # Arguments
     ///
-    /// * `from_block` - From which block the messages should be gathered.
+    /// * `gather_from_block` - From which block the messages should be gathered.
     /// * `max_block` - The number of block fetched in the event/log filter. A too big value can
     ///   cause the RPC node to reject the query.
     /// * `chain_id` - The sequencer chain id for transaction hash computation.
     async fn gather_messages(
         &self,
-        from_block: u64,
+        gather_from_block: u64,
         max_blocks: u64,
         chain_id: ChainId,
     ) -> MessengerResult<(u64, Vec<Self::MessageTransaction>)>;

--- a/crates/katana/core/src/service/messaging/mod.rs
+++ b/crates/katana/core/src/service/messaging/mod.rs
@@ -39,6 +39,9 @@ use tokio::sync::RwLock as AsyncRwLock;
 mod ethereum;
 mod service;
 mod starknet;
+mod utils;
+use alloy_primitives::B256;
+
 
 use std::path::Path;
 
@@ -108,6 +111,13 @@ pub struct MessagingConfig {
     pub interval: u64,
     /// The block on settlement chain from where Katana will start fetching messages.
     pub from_block: u64,
+
+    pub tx_hash : B256, //ou bytes?
+
+    pub msg_hash : B256 //ou bytes?
+
+    //commencer avec quoi comme default tx_hash/msg_hash? rien? 
+    //ici
 }
 
 impl MessagingConfig {

--- a/crates/katana/core/src/service/messaging/mod.rs
+++ b/crates/katana/core/src/service/messaging/mod.rs
@@ -110,11 +110,15 @@ pub struct MessagingConfig {
     /// from/to the settlement chain.
     pub interval: u64,
     /// The block on settlement chain from where Katana will start fetching messages.
-    pub from_block: u64,
+    pub gather_from_block: u64,
 
-    pub tx_hash : B256, //ou bytes?
+    pub send_from_block: u64,
 
-    pub msg_hash : B256 //ou bytes?
+    pub path : String,
+
+    pub tx_hash : B256, 
+
+    //pub msg_hash : B256 
 
     //commencer avec quoi comme default tx_hash/msg_hash? rien? 
     //ici
@@ -123,9 +127,16 @@ pub struct MessagingConfig {
 impl MessagingConfig {
     /// Load the config from a JSON file.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
-        let buf = std::fs::read(path)?;
-        serde_json::from_slice(&buf).map_err(|e| e.into())
+        /*let buf = std::fs::read(path)?;
+        serde_json::from_slice(&buf).map_err(|e| e.into())*/
+        let path_ref = path.as_ref();
+        let buf = std::fs::read(path_ref)?;
+        let mut config: MessagingConfig = serde_json::from_slice(&buf)?;
+        config.path = path_ref.to_string_lossy().into_owned();
+        Ok(config)
     }
+
+    //ici?
 
     /// This is used as the clap `value_parser` implementation
     pub fn parse(path: &str) -> Result<Self, String> {
@@ -195,7 +206,7 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> MessengerMode<EF> {
                 }
             },
 
-            CONFIG_CHAIN_STARKNET => match StarknetMessaging::new(config, hooker).await {
+            CONFIG_CHAIN_STARKNET => match StarknetMessaging::new(config, hooker).await { //ici !!
                 Ok(m_sn) => {
                     info!(target: LOG_TARGET, "Messaging enabled [Starknet].");
                     Ok(MessengerMode::Starknet(m_sn))

--- a/crates/katana/core/src/service/messaging/service.rs
+++ b/crates/katana/core/src/service/messaging/service.rs
@@ -146,7 +146,18 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
                     let hash = tx.calculate_hash();
                     info!(target: LOG_TARGET, "Processing transaction with hash: {:#x}", hash);
                     trace_l1_handler_tx_exec(hash, &tx);
-                    if count == 1 {
+
+
+                    //This is for the first time, we read 00...00 from the config but it's okay.
+                    let mut buffer = [0u8; 32];  // Initialize a buffer with 32 zero bytes
+                    let bytes = "0000000000000000000000000000000000000000000000000000000000000000".as_bytes(); // Convert the string to a byte slice
+                    // Copy the bytes to the buffer, up to 32 bytes
+                    let len = std::cmp::min(bytes.len(), 32);
+                    buffer[..len].copy_from_slice(&bytes[..len]);
+
+
+
+                    if count == 1 || tx_hash == buffer {
                         pool.add_transaction(ExecutableTxWithHash { hash, transaction: tx.clone().into() }); // ici condition, on skip et on ajoute le prochain
                     }
                     //ici, enregistrer msg hash et block number 

--- a/crates/katana/core/src/service/messaging/utils.rs
+++ b/crates/katana/core/src/service/messaging/utils.rs
@@ -1,0 +1,71 @@
+use std::fs::OpenOptions;
+use std::io::{self, Read, Write, Seek};
+use serde_json::Value;
+use alloy_primitives::B256;
+use starknet_api::hash::{PoseidonHash};
+
+
+
+/// Updates the last sent block number in the JSON file.
+pub fn update_l2(new_block_num: u64, tx_hash : B256) {
+    let path = "../../../../contracts/messaging/anvil.messaging.json";
+    
+   // Open the file with options to read and write without truncating.
+   let mut file = OpenOptions::new()
+   .read(true)
+   .write(true)
+   .open(path).expect("msg");
+
+    // Read the existing content into a string.
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).expect("msg");
+
+    // Parse the JSON string into a serde_json::Value object.
+    let mut data: Value = serde_json::from_str(&contents).expect("msg");
+
+    // Update the 'from_block' field with the new block number.
+    if let Some(obj) = data.as_object_mut() {
+    obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
+    obj.insert("tx_hash".to_string(), serde_json::json!(tx_hash));
+    }
+
+    // Move back to the start of the file and truncate it to zero length.
+    file.set_len(0).expect("msg");
+    file.seek(io::SeekFrom::Start(0)).expect("msg");
+
+    // Write the updated JSON back to the file.
+    write!(file, "{}", data).expect("msg");
+}
+
+
+/// Updates the last sent block number in the JSON file.
+pub fn update_l3(new_block_num: u64, msg_hash : PoseidonHash) {
+    let path = "../../../../contracts/messaging/l3.messaging.json";
+    
+   // Open the file with options to read and write without truncating.
+   let mut file = OpenOptions::new()
+   .read(true)
+   .write(true)
+   .open(path).expect("msg");
+
+    // Read the existing content into a string.
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).expect("msg");
+
+    // Parse the JSON string into a serde_json::Value object.
+    let mut data: Value = serde_json::from_str(&contents).expect("msg");
+
+    // Update the 'from_block' field with the new block number.
+    if let Some(obj) = data.as_object_mut() {
+    obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
+    obj.insert("msg_hash".to_string(), serde_json::json!(msg_hash));
+    }
+
+    // Move back to the start of the file and truncate it to zero length.
+    file.set_len(0).expect("msg");
+    file.seek(io::SeekFrom::Start(0)).expect("msg");
+
+    // Write the updated JSON back to the file.
+    write!(file, "{}", data).expect("msg");
+
+}

--- a/crates/katana/core/src/service/messaging/utils.rs
+++ b/crates/katana/core/src/service/messaging/utils.rs
@@ -2,13 +2,13 @@ use std::fs::OpenOptions;
 use std::io::{self, Read, Write, Seek};
 use serde_json::Value;
 use alloy_primitives::B256;
-use starknet_api::hash::{PoseidonHash};
+use starknet_api::hash::PoseidonHash;
 
 
 
 /// Updates the last sent block number in the JSON file.
-pub fn update_l2(new_block_num: u64, tx_hash : B256) {
-    let path = "../../../../contracts/messaging/anvil.messaging.json";
+pub fn update_l2_block(new_block_num: u64, path : String) {
+    //let path = "../../../../contracts/messaging/anvil.messaging.json";
     
    // Open the file with options to read and write without truncating.
    let mut file = OpenOptions::new()
@@ -26,6 +26,37 @@ pub fn update_l2(new_block_num: u64, tx_hash : B256) {
     // Update the 'from_block' field with the new block number.
     if let Some(obj) = data.as_object_mut() {
     obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
+    //obj.insert("tx_hash".to_string(), serde_json::json!(tx_hash));
+    }
+
+    // Move back to the start of the file and truncate it to zero length.
+    file.set_len(0).expect("msg");
+    file.seek(io::SeekFrom::Start(0)).expect("msg");
+
+    // Write the updated JSON back to the file.
+    write!(file, "{}", data).expect("msg");
+}
+
+/// Updates the last sent block number in the JSON file.
+pub fn update_l2_hash(tx_hash : B256, path : String) {
+    //let path = "../../../../contracts/messaging/anvil.messaging.json";
+    
+   // Open the file with options to read and write without truncating.
+   let mut file = OpenOptions::new()
+   .read(true)
+   .write(true)
+   .open(path).expect("msg");
+
+    // Read the existing content into a string.
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).expect("msg");
+
+    // Parse the JSON string into a serde_json::Value object.
+    let mut data: Value = serde_json::from_str(&contents).expect("msg");
+
+    // Update the 'from_block' field with the new block number.
+    if let Some(obj) = data.as_object_mut() {
+    //obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
     obj.insert("tx_hash".to_string(), serde_json::json!(tx_hash));
     }
 
@@ -39,8 +70,8 @@ pub fn update_l2(new_block_num: u64, tx_hash : B256) {
 
 
 /// Updates the last sent block number in the JSON file.
-pub fn update_l3(new_block_num: u64, msg_hash : PoseidonHash) {
-    let path = "../../../../contracts/messaging/l3.messaging.json";
+pub fn update_l3(new_block_num: u64, /*msg_hash : PoseidonHash,*/ path : String) {
+    //let path = "../../../../contracts/messaging/l3.messaging.json";
     
    // Open the file with options to read and write without truncating.
    let mut file = OpenOptions::new()
@@ -58,7 +89,7 @@ pub fn update_l3(new_block_num: u64, msg_hash : PoseidonHash) {
     // Update the 'from_block' field with the new block number.
     if let Some(obj) = data.as_object_mut() {
     obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
-    obj.insert("msg_hash".to_string(), serde_json::json!(msg_hash));
+    //obj.insert("msg_hash".to_string(), serde_json::json!(msg_hash));
     }
 
     // Move back to the start of the file and truncate it to zero length.

--- a/crates/katana/core/src/service/messaging/utils.rs
+++ b/crates/katana/core/src/service/messaging/utils.rs
@@ -25,7 +25,7 @@ pub fn update_l2_block(new_block_num: u64, path : String) {
 
     // Update the 'from_block' field with the new block number.
     if let Some(obj) = data.as_object_mut() {
-    obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
+    obj.insert("gather_from_block".to_string(), serde_json::json!(new_block_num));
     //obj.insert("tx_hash".to_string(), serde_json::json!(tx_hash));
     }
 
@@ -88,7 +88,7 @@ pub fn update_l3(new_block_num: u64, /*msg_hash : PoseidonHash,*/ path : String)
 
     // Update the 'from_block' field with the new block number.
     if let Some(obj) = data.as_object_mut() {
-    obj.insert("from_block".to_string(), serde_json::json!(new_block_num));
+    obj.insert("send_from_block".to_string(), serde_json::json!(new_block_num));
     //obj.insert("msg_hash".to_string(), serde_json::json!(msg_hash));
     }
 


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Save checkpoint when katana is crashing, so that on restart it does not restart from the beginning.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
