### PR TITLE
feat(katana): prevent sequencer to treat all block from start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11403,6 +11409,7 @@ dependencies = [
  "common",
  "console",
  "dojo-metrics",
+ "dotenv",
  "katana-core",
  "katana-executor",
  "katana-primitives",

--- a/bin/solis/Cargo.toml
+++ b/bin/solis/Cargo.toml
@@ -19,6 +19,7 @@ clap_complete.workspace = true
 common.workspace = true
 console.workspace = true
 dojo-metrics.workspace = true
+dotenv = "0.15.0"
 katana-core.workspace = true
 katana-executor.workspace = true
 katana-primitives.workspace = true

--- a/bin/solis/src/args.rs
+++ b/bin/solis/src/args.rs
@@ -9,7 +9,7 @@
 //!   and leak detection functionality. See [jemalloc's opt.prof](https://jemalloc.net/jemalloc.3.html#opt.prof)
 //!   documentation for usage details. This is **not recommended on Windows**. See [here](https://rust-lang.github.io/rfcs/1974-global-allocators.html#jemalloc)
 //!   for more info.
-
+use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 

--- a/bin/solis/src/main.rs
+++ b/bin/solis/src/main.rs
@@ -43,6 +43,8 @@ pub(crate) const LOG_TARGET: &str = "katana::cli";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::dotenv().ok();
+
     let args = KatanaArgs::parse();
     args.init_logging()?;
 

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -225,8 +225,8 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> Messenger for StarknetM
 
     async fn gather_messages(
         &self,
-        from_block: u64,
-        max_blocks: u64,
+        _from_block: u64,
+        _max_blocks: u64,
         chain_id: ChainId,
     ) -> MessengerResult<(u64, Vec<L1HandlerTx>)> {
         debug!(target: LOG_TARGET, "Gathering messages");

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::hooker::KatanaHooker;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -67,6 +68,52 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> StarknetMessaging<EF> {
             event_cache: Arc::new(AsyncRwLock::new(HashSet::new())),
             latest_block,
         })
+    }
+
+    /// Fetches events for the given blocks range.
+    pub async fn fetch_events(
+        &self,
+        from_block: BlockId,
+        to_block: BlockId,
+    ) -> Result<HashMap<u64, Vec<EmittedEvent>>> {
+        trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching logs.");
+
+        let mut block_to_events: HashMap<u64, Vec<EmittedEvent>> = HashMap::new();
+
+        let filter = EventFilter {
+            from_block: Some(from_block),
+            to_block: Some(to_block),
+            address: Some(self.messaging_contract_address),
+            // TODO: this might come from the configuration actually.
+            keys: None,
+        };
+
+        // TODO: this chunk_size may also come from configuration?
+        let chunk_size = 200;
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let event_page =
+                self.provider.get_events(filter.clone(), continuation_token, chunk_size).await?;
+
+            event_page.events.into_iter().for_each(|event| {
+                // We ignore events without the block number
+                if let Some(block_number) = event.block_number {
+                    block_to_events
+                        .entry(block_number)
+                        .and_modify(|v| v.push(event.clone()))
+                        .or_insert(vec![event]);
+                }
+            });
+
+            continuation_token = event_page.continuation_token;
+
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(block_to_events)
     }
 
     async fn fetch_pending_events(&self, chain_id: ChainId) -> MessengerResult<Vec<L1HandlerTx>> {
@@ -225,8 +272,8 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> Messenger for StarknetM
 
     async fn gather_messages(
         &self,
-        _from_block: u64,
-        _max_blocks: u64,
+        from_block: u64,
+        max_blocks: u64,
         chain_id: ChainId,
     ) -> MessengerResult<(u64, Vec<L1HandlerTx>)> {
         debug!(target: LOG_TARGET, "Gathering messages");
@@ -245,6 +292,41 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> Messenger for StarknetM
             }
         };
 
+        if from_block > chain_latest_block {
+            // Nothing to fetch, we can skip waiting the next tick.
+            return Ok((chain_latest_block, vec![]));
+        }
+
+        // +1 as the from_block counts as 1 block fetched.
+        let to_block = if from_block + max_blocks + 1 < chain_latest_block {
+            from_block + max_blocks
+        } else {
+            chain_latest_block
+        };
+
+        let mut l1_handler_txs: Vec<L1HandlerTx> = vec![];
+
+        // fetch events for the given range before fetching pending events
+        self.fetch_events(BlockId::Number(from_block), BlockId::Number(to_block))
+            .await
+            .map_err(|_| Error::SendError)
+            .unwrap()
+            .iter()
+            .for_each(|(block_number, block_events)| {
+                debug!(
+                    target: LOG_TARGET,
+                    block_number = %block_number,
+                    events_count = %block_events.len(),
+                    "Converting events of block into L1HandlerTx."
+                );
+
+                block_events.iter().for_each(|e| {
+                    if let Ok(tx) = l1_handler_tx_from_event(e, chain_id) {
+                        l1_handler_txs.push(tx)
+                    }
+                })
+            });
+
         // Check if the block number has changed
         let previous_block = self.latest_block.load(Ordering::Relaxed);
         if previous_block != chain_latest_block {
@@ -252,11 +334,13 @@ impl<EF: katana_executor::ExecutorFactory + Send + Sync> Messenger for StarknetM
             self.event_cache.write().await.clear();
             self.latest_block.store(chain_latest_block, Ordering::Relaxed);
         }
-
+        // Fetch pending events
         let pending_txs = self.fetch_pending_events(chain_id).await?;
-        debug!(target: LOG_TARGET, "Returning {} pending transactions", pending_txs.len());
+        // Add pending events to the list
+        l1_handler_txs.extend(pending_txs);
 
-        Ok((chain_latest_block, pending_txs))
+        debug!(target: LOG_TARGET, "Returning {} transactions", l1_handler_txs.len());
+        Ok((chain_latest_block, l1_handler_txs))
     }
 
     async fn send_messages(


### PR DESCRIPTION
# Description

1. add new fields in config file send_from_block & config_file
2. rename from_block to gather_from_block
3. update send_from_block poll_next method
4. use new send_from_block to start to send transactions 

<!--
A description of what this PR is solving.
-->

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
